### PR TITLE
Bugfixes for 1.1.0

### DIFF
--- a/extensions/logging/main.js
+++ b/extensions/logging/main.js
@@ -10,7 +10,8 @@
  */
 const fs = require('fs'),
       io = require('../../includes/io.js'),
-      Extension = require('../extension.js');
+      Extension = require('../extension.js'),
+      util = require('../../includes/util.js');
 
 /**
  * Constants
@@ -95,9 +96,8 @@ class Logging extends Extension {
                 }
             }
             this._callWebhook(text, nickname);
-            
         } else if(message.command === 'PRIVMSG') {
-            this._write('PM', `<${nickname}> ${message}`);
+            this._write('PM', `<${nickname}> ${text}`);
         }
     }
     /**
@@ -252,6 +252,21 @@ class Logging extends Extension {
         this._write('PART', `${nickname} -> ${channel}: "${reason}"`);
         if(channel === this._channel) {
             this._callWebhook(`${nickname} left ("${reason}")`);
+        }
+    }
+    /**
+     * Event called when a user quits IRC
+     * @method _onQuit
+     * @private
+     * @param {String} nickname Nickname of the user that quit
+     * @param {String} reason Reason for quitting
+     * @param {String} channels Channels the user quit
+     */
+    _onQuit(nickname, reason, channels) {
+        reason = reason || 'No reason specified';
+        this._write('QUIT', `${nickname} ("${reason}")`);
+        if(util.includes(channels, this._channel)) {
+            this._callWebhook(`${nickname} quit ("${reason}")`);
         }
     }
     /**

--- a/includes/client.js
+++ b/includes/client.js
@@ -22,7 +22,8 @@ const EVENTS = [
     'registered',
     'notice',
     'part',
-    'kick'
+    'kick',
+    'quit'
 ], CHANNELS = [
     'cvn-wikia',
     'wikia-discussions'
@@ -54,7 +55,6 @@ class Client {
         util.each(this._config.filters, function(k, v) {
             if(v.name) {
                 const Filter = main.filters[v.name];
-                delete v.name;
                 if(Filter) {
                     this._filters[k] = new Filter(k, v);
                 }
@@ -72,7 +72,6 @@ class Client {
         util.each(this._config.transports, function(k, v) {
             if(v.name) {
                 const Transport = main.transports[v.name];
-                delete v.name;
                 if(Transport) {
                     this._transports[k] = new Transport(v);
                 }
@@ -217,6 +216,18 @@ class Client {
      */
     _onKick(channel, nickname, user, reason, message) {
         main.hook('kick', channel, nickname, user, reason, message);
+    }
+    /**
+     * Event called when a user quits IRC
+     * @method _onQuit
+     * @private
+     * @param {String} nickname Nickname of the user that quit
+     * @param {String} reason Reason for quitting
+     * @param {String} channels Channels the user quit
+     * @param {Object} message IRC message object
+     */
+    _onQuit(nickname, reason, channels, message) {
+        main.hook('quit', nickname, reason, channels, message);
     }
     /**
      * Kills the IRC client

--- a/includes/msg.js
+++ b/includes/msg.js
@@ -16,7 +16,7 @@ const util = require('./util.js');
  * @todo Move this to a JSON file?
  */
 const REGEX = {
-    discussions: /\[\[User:([^\]]+)\]\] (replied|reported post|(created|deleted|undeleted|moved|edited) (thread|report|reply))(?: \[\[([^\]]+)\]\])?(?: \((\d+)\))? http:\/\/(.+)\.wikia\.com\/d\/p\/(\d{19})(?:\/r\/(\d{19}))? : (.*)/, // jshint ignore:line
+    discussions: /\[\[User:([^\]]+)\]\] (replied|reported post|(created|deleted|undeleted|moved|edited) (thread|report|reply))(?: \[\[(.+)\]\])?(?: \((\d+)\))? http:\/\/(.+)\.wikia\.com\/d\/p\/(\d{19})(?:\/r\/(\d{19}))? : (.*)/, // jshint ignore:line
     edit: /^(User|IP|Whitelist|Blacklist|Watchlist|Admin|Greylist) \[\[User:([^\]]+)\]\] (edited|created|used edit summary "([^"]+)"( in creating)*|Copyvio\?|Tiny create|Possible gibberish\?|Large removal|create containing watch word "([^"]+)"|blanked) \[\[([^\]]+)\]\] \(([\+-\d]+)\) (URL|Diff): http:\/\/([^\s]+)\.wikia\.com\/(?:index\.php\?|\?|wiki\/)*([^\s]+)(?: (.*))*/g, // jshint ignore:line
     replace: /^(User|IP|Whitelist|Blacklist|Watchlist|Admin|Greylist) \[\[User:([^\]]+)\]\] replaced \[\[([^\]]+)\]\] with "(.*)" \(([\+-\d]+)\) Diff: http:\/\/([^\s]+)\.wikia\.com\/\?([^\s]+)/g, // jshint ignore:line
     block: /^(Block|Unblock) [eE]ditor \[\[User:([^\]]+)\]\] (?:blocked|unblocked) by admin \[\[User:([^\]]+)\]\] (?:Length: (.*) )*"([^"]+)"/g, // jshint ignore:line

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cvn-advanced",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Listens for, filters and transports activity from Wikia countervandalism channels",
     "keywords": [
         "wikia",


### PR DESCRIPTION
- PMs will be logged correctly in the `logging` extension
- Leaving is not limited to `part` event anymore, it listens for `quit` now. Possibly will have to listen for `kill` in future as well
- Fixed parsing error where Discussions activity for new threads failed to parse if the thread title contained `[` or `]`.
- Fixed error when editing configuration through IRC