### PR TITLE
Update 1.2.1

### DIFF
--- a/docs/Message.md
+++ b/docs/Message.md
@@ -129,6 +129,7 @@ It can also contain the following properties:
 | `url`      | String  | URL that was inserted                     | `COI5.4` was hit               |
 | `summary`  | String  | Summary that was used                     | `COI5.3` was hit               |
 | `xrumer`   | Boolean | If XRumer spam (`XRM`) has been detected  | Always                         |
+| `thread`   | Boolean | If thread spam (`THR`) has been detected  | Always                         |
 | `filter`   | Integer | Filter that was hit                       | `coi` is 5                     |
 | `content`  | String  | Content of the filter that was hit        | `coi` is 5                     |
 | `mainUser` | String  | Second user involved in `ANS` spam        | `coi` is 6                     |

--- a/formats/newusers/main.js
+++ b/formats/newusers/main.js
@@ -24,11 +24,10 @@ const PROPERTY_MAP = {
     fbPage: 'Facebook',
     twitter: 'Twitter',
     bio: 'Bio'
-}, PREFIXES = {
+}, /* eslint-enable */ PREFIXES = {
     fbPage: 'https://facebook.com/',
     twitter: 'https://twitter.com/'
 };
-/* eslint-enable */
 
 /**
  * Main class
@@ -50,7 +49,7 @@ class ExampleFormat extends Format {
         const ret = {
             fields: [],
             title: info.username,
-            url: `https://${wiki}.wikia.com/wiki/Special:Contribs/${user}`
+            url: `${util.wiki(wiki)}/wiki/Special:Contribs/${user}`
         };
         if (info.avatar) {
             ret.image = {

--- a/formats/spam/main.js
+++ b/formats/spam/main.js
@@ -73,7 +73,9 @@ class SpamFormat extends Format {
         switch (msg.coi) {
             case 1: return msg.xrumer ?
                 'XRumer spam' :
-                'Inserted link matches username';
+                msg.thread ?
+                    'Thread spam' :
+                   'Inserted link matches username';
             case 2: return 'Wiki URL similar to founder';
             case 3: return 'Wiki name similar to founder';
             case 4: return 'Inserted a link to a new wiki too soon';
@@ -101,7 +103,7 @@ class SpamFormat extends Format {
         if (msg.oldid) {
             return `${wiki}/?oldid=${msg.oldid}`;
         } else if (msg.reply) {
-            return `${wiki}/d/p/${msg.thread}/${msg.reply}`;
+            return `${wiki}/d/p/${msg.thread}/r/${msg.reply}`;
         } else if (msg.thread) {
             return `${wiki}/d/p/${msg.thread}`;
         } else if (msg.coi === 6) {

--- a/includes/msg.js
+++ b/includes/msg.js
@@ -341,6 +341,8 @@ class Message {
             case 'matching criteria:':
                 if (content === 'IP and title equals summary') {
                     this.xrumer = true;
+                } else if (content === 'user and URL addition to Wall') {
+                    this.thread = true;
                 } else {
                     this._debug(`Unknown criteria: ${content}`);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "requires": {
-                "acorn": "3.3.0"
+                "acorn": "^3.0.4"
             },
             "dependencies": {
                 "acorn": {
@@ -29,8 +29,8 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
             "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
             "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
             }
         },
         "ajv-keywords": {
@@ -58,7 +58,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "array-union": {
@@ -66,7 +66,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -109,9 +109,9 @@
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -119,11 +119,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -131,7 +131,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 }
             }
@@ -147,7 +147,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "bignumber.js": {
@@ -160,7 +160,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -168,7 +168,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -182,7 +182,7 @@
             "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsites": {
@@ -200,9 +200,9 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
             "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.3.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -210,7 +210,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "supports-color": {
@@ -218,7 +218,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -238,7 +238,7 @@
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-width": {
@@ -256,7 +256,7 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -269,7 +269,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "concat-map": {
@@ -282,10 +282,10 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "requires": {
-                "buffer-from": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "core-util-is": {
@@ -298,9 +298,9 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "requires": {
-                "lru-cache": "4.1.2",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
@@ -308,7 +308,7 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "dashdash": {
@@ -316,7 +316,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -344,13 +344,13 @@
             "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             }
         },
         "delayed-stream": {
@@ -363,7 +363,7 @@
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "ecc-jsbn": {
@@ -372,7 +372,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "escape-string-regexp": {
@@ -385,44 +385,44 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "requires": {
-                "ajv": "5.5.2",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.3.2",
-                "concat-stream": "1.6.2",
-                "cross-spawn": "5.1.0",
-                "debug": "3.1.0",
-                "doctrine": "2.1.0",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0",
-                "espree": "3.5.4",
-                "esquery": "1.0.1",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "11.4.0",
-                "ignore": "3.3.7",
-                "imurmurhash": "0.1.4",
-                "inquirer": "3.3.0",
-                "is-resolvable": "1.1.0",
-                "js-yaml": "3.11.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.4",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "regexpp": "1.1.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.5.0",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
+                "ajv": "^5.3.0",
+                "babel-code-frame": "^6.22.0",
+                "chalk": "^2.1.0",
+                "concat-stream": "^1.6.0",
+                "cross-spawn": "^5.1.0",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^3.7.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^3.5.4",
+                "esquery": "^1.0.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.0.1",
+                "ignore": "^3.3.3",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^3.0.6",
+                "is-resolvable": "^1.0.0",
+                "js-yaml": "^3.9.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^1.0.1",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.3.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "~2.0.1",
                 "table": "4.0.2",
-                "text-table": "0.2.0"
+                "text-table": "~0.2.0"
             },
             "dependencies": {
                 "ajv": {
@@ -430,10 +430,10 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
                     "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 }
             }
@@ -443,8 +443,8 @@
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "eslint-visitor-keys": {
@@ -457,8 +457,8 @@
             "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "requires": {
-                "acorn": "5.5.3",
-                "acorn-jsx": "3.0.1"
+                "acorn": "^5.5.0",
+                "acorn-jsx": "^3.0.0"
             }
         },
         "esprima": {
@@ -471,7 +471,7 @@
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -479,7 +479,7 @@
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -502,9 +502,9 @@
             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.21",
-                "tmp": "0.0.33"
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
             }
         },
         "extsprintf": {
@@ -532,7 +532,7 @@
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -540,8 +540,8 @@
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "flat-cache": {
@@ -549,10 +549,10 @@
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             }
         },
         "forever-agent": {
@@ -565,9 +565,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "fs.realpath": {
@@ -585,7 +585,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -600,12 +600,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "globals": {
@@ -618,12 +618,12 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "graceful-fs": {
@@ -641,8 +641,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
             }
         },
         "has-ansi": {
@@ -650,7 +650,7 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -663,10 +663,10 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "hoek": {
@@ -679,9 +679,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "iconv": {
@@ -690,7 +690,7 @@
             "integrity": "sha1-4ITWDut9c9p/CpwJbkyKvgkL+u0=",
             "optional": true,
             "requires": {
-                "nan": "2.6.2"
+                "nan": "^2.3.5"
             }
         },
         "iconv-lite": {
@@ -698,7 +698,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
             "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "^2.1.0"
             }
         },
         "ignore": {
@@ -716,8 +716,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -730,20 +730,20 @@
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.3.2",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.2.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.4",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             }
         },
         "irc": {
@@ -751,9 +751,9 @@
             "resolved": "https://registry.npmjs.org/irc/-/irc-0.5.2.tgz",
             "integrity": "sha1-NxT0doNlqW0LL3dryRFmvrJGS7w=",
             "requires": {
-                "iconv": "2.2.3",
-                "irc-colors": "1.3.3",
-                "node-icu-charset-detector": "0.2.0"
+                "iconv": "~2.2.1",
+                "irc-colors": "^1.1.0",
+                "node-icu-charset-detector": "~0.2.0"
             }
         },
         "irc-colors": {
@@ -776,7 +776,7 @@
             "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -784,7 +784,7 @@
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-promise": {
@@ -827,8 +827,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
             "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -852,7 +852,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stable-stringify-without-jsonify": {
@@ -893,8 +893,8 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "lodash": {
@@ -907,8 +907,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
             "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "mime-db": {
@@ -921,7 +921,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
             "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
             "requires": {
-                "mime-db": "1.27.0"
+                "mime-db": "~1.27.0"
             }
         },
         "mimic-fn": {
@@ -934,7 +934,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -988,7 +988,7 @@
             "integrity": "sha1-wjINo3Tdy2cfxUy0oOBB4Vb/1jk=",
             "optional": true,
             "requires": {
-                "nan": "2.6.2"
+                "nan": "^2.3.3"
             }
         },
         "oauth-sign": {
@@ -1006,7 +1006,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -1014,7 +1014,7 @@
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "optionator": {
@@ -1022,12 +1022,12 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "os-tmpdir": {
@@ -1065,7 +1065,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pluralize": {
@@ -1108,13 +1108,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
             "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             }
         },
         "regexpp": {
@@ -1127,28 +1127,28 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.15",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
             }
         },
         "request-promise-core": {
@@ -1156,7 +1156,7 @@
             "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.13.1"
             }
         },
         "request-promise-native": {
@@ -1165,8 +1165,8 @@
             "integrity": "sha1-hpiOyO7kCORVefzoO/0Fs635oVU=",
             "requires": {
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.2"
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.0"
             }
         },
         "require-uncached": {
@@ -1174,8 +1174,8 @@
             "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "resolve-from": {
@@ -1188,8 +1188,8 @@
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "rimraf": {
@@ -1197,7 +1197,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "run-async": {
@@ -1205,7 +1205,7 @@
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "rx-lite": {
@@ -1218,7 +1218,7 @@
             "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "requires": {
-                "rx-lite": "4.0.8"
+                "rx-lite": "*"
             }
         },
         "safe-buffer": {
@@ -1241,7 +1241,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -1259,7 +1259,7 @@
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "sntp": {
@@ -1267,7 +1267,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "sprintf-js": {
@@ -1285,14 +1285,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1312,8 +1312,8 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string_decoder": {
@@ -1321,7 +1321,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -1334,7 +1334,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1359,12 +1359,12 @@
             "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.3.2",
-                "lodash": "4.17.4",
+                "ajv": "^5.2.3",
+                "ajv-keywords": "^2.1.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             },
             "dependencies": {
                 "ajv": {
@@ -1372,10 +1372,10 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
                     "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 }
             }
@@ -1395,7 +1395,7 @@
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "tough-cookie": {
@@ -1403,7 +1403,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
             "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tunnel-agent": {
@@ -1411,7 +1411,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -1425,7 +1425,7 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "typedarray": {
@@ -1456,7 +1456,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "wordwrap": {
@@ -1474,7 +1474,7 @@
             "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "yallist": {


### PR DESCRIPTION
# Update 1.2.1
## Fixes
- New users format will no longer show security warnings when visiting links to foreign wikis
- There was apparently a security vulnerability in dependencies, thanks GitHub
- Linking to Discussions replies in the spam format will now work
## New stuff
- THR is now supported